### PR TITLE
fix: display:flex によるスクロール時の透明タブ問題を修正

### DIFF
--- a/src/content/adapters/bing.ts
+++ b/src/content/adapters/bing.ts
@@ -5,14 +5,14 @@ import { getAllSettings } from '../../utils/settings';
 
 export class BingAdapter extends BaseSiteAdapter {
   findTabsContainer(): HTMLElement | null {
-    return get('nav[role="navigation"]');
+    return get('nav[role="navigation"] ul');
   }
 
   findTabs(): HTMLElement[] | null {
     const container = this.findTabsContainer();
     if (!container) return null;
-    get('ul', container)?.style.setProperty('display', 'flex');
-    return Array.from(getAll('ul li', container)) as HTMLElement[];
+    container.style.setProperty('display', 'flex');
+    return Array.from(getAll('li', container)) as HTMLElement[];
   }
 
   findTabsInfo(): TabInfo[] | null {
@@ -47,8 +47,6 @@ export class BingAdapter extends BaseSiteAdapter {
   showTabs(): void {
     const container = this.findTabsContainer();
     if (container) {
-      // Bingのタブ内を横並びに表示するためにflexに設定
-      container.style.display = 'flex';
       container.style.visibility = 'visible';
     }
   }


### PR DESCRIPTION
Correct the method for retrieving the tabs container and enhance the display style to ensure tabs are displayed in a horizontal layout.